### PR TITLE
Symlinks

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2018-04-02  Christoph Schulz <ch.schulz@joinout.de>
+
+	* Add support for de-duplication using symlinks
+
 2012-08-27  Christian Weiske  <cweiske@bogo>
 
 	* Add support for OpenIDs

--- a/data/surrogator.config.php.dist
+++ b/data/surrogator.config.php.dist
@@ -43,4 +43,9 @@ $logLevel = 1;
  * to true, the images will always be regenerated.
  */
 $forceUpdate = false;
+
+/**
+ * By default, no symlinks are created.
+ */
+$useSymlinks = true;
 ?>


### PR DESCRIPTION
I've patched Surrogator to support symlinks for de-duplication.

My use-case is that I have the same image for multiple of mail
addresses and my OpenID and would store the image sizes 3x, which did not make sense to me.

I added a `-s`/`--symlink` flag and an `$useSymlinks` configuration option that enables this behaviour.

Thank you. :)