### PR TITLE
fix filename parsing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ www/robots.txt
 build.properties
 dist/
 /vendor/
+.idea/

--- a/surrogator.php
+++ b/surrogator.php
@@ -205,7 +205,7 @@ function getHashes($fileName)
     //OpenIDs have their slashes "/" url-encoded
     $fileName = rawurldecode($fileName);
 
-    $fileNameNoExt = substr($fileName, 0, -strlen(strrpos($fileName, '.')) - 2);
+    $fileNameNoExt = pathinfo($fileName, PATHINFO_FILENAME);
     $emailAddress  = trim(strtolower($fileNameNoExt));
 
     return array(


### PR DESCRIPTION
Hi!

I noticed that the substring method does not always return the expected strings. I replaced it with `pathinfo` to more reliably fetch the filename without the extension. 

Here's a small example of what happens with shorter filenames, the dot is not removed.
![Screenshot 2024-07-04 at 20 58 33](https://github.com/cweiske/surrogator/assets/16179620/43e8cff8-d19c-4f79-9bab-eb20fcdd7f96)
